### PR TITLE
fix: updates package name to scoped `@dcforge/image-specs`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,17 +165,17 @@ jobs:
           mkdir -p /tmp/test-install
           cd /tmp/test-install
           npm init -y
-          npm install ${{ github.workspace }}/image-specs-*.tgz
+          npm install ${{ github.workspace }}/dcforge-image-specs-*.tgz
 
       - name: Test ESM import
         run: |
           cd /tmp/test-install
-          node -e "import('image-specs').then(m => console.log('✅ ESM import works:', typeof m.getImageSpecs))"
+          node -e "import('@dcforge/image-specs').then(m => console.log('✅ ESM import works:', typeof m.getImageSpecs))"
 
       - name: Test CJS require
         run: |
           cd /tmp/test-install
-          node -e "const { getImageSpecs } = require('image-specs'); console.log('✅ CJS require works:', typeof getImageSpecs)"
+          node -e "const { getImageSpecs } = require('@dcforge/image-specs'); console.log('✅ CJS require works:', typeof getImageSpecs)"
 
       - name: Test CLI binary
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,7 +270,7 @@ jobs:
       - name: Verify npm publication
         run: |
           sleep 30  # Wait for npm registry to update
-          npm view image-specs@${{ needs.release.outputs.version }} version || exit 1
+          npm view @dcforge/image-specs@${{ needs.release.outputs.version }} version || exit 1
           echo "✅ Package successfully published to npm"
 
   notify:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # image-specs
 
-[![npm version](https://badge.fury.io/js/image-specs.svg)](https://badge.fury.io/js/image-specs)
+[![npm version](https://badge.fury.io/js/image-specs.svg)](https://badge.fury.io/js/@dcforge/image-specs)
 [![TypeScript](https://badges.frapsoft.com/typescript/love/typescript.svg?v=101)](https://github.com/ellerbrock/typescript-badges/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "image-specs",
+  "name": "@dcforge/image-specs",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "image-specs",
+      "name": "@dcforge/image-specs",
       "version": "1.0.0",
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "image-specs",
+  "name": "@dcforge/image-specs",
   "version": "1.0.0",
   "description": "Extract image specifications from URLs or streams with TypeScript support",
   "keywords": [


### PR DESCRIPTION
Updates the package name to the scoped `@dcforge/image-specs` to align with the organization's naming convention on npm.

This change ensures proper identification and management of the package within the dcforge ecosystem, and updates the npm publication verification step in the release workflow.