### PR TITLE
chore(ci): bump GitHub Actions (codecov v7, dependency-review v5, setup-node v7, github-script v9, labeler v7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: '22.22.1'
           cache: npm
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload coverage
         if: matrix.coverage == true
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: ./coverage/coverage-final.json
           flags: unittests

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: moderate
           deny-licenses: GPL-3.0, AGPL-3.0

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Comment on large PR
         if: steps.diff.outputs.total > 500
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const total = ${{ steps.diff.outputs.total }};
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Apply labels
-        uses: actions/labeler@v6
+        uses: actions/labeler@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
           persist-credentials: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: '22.22.1'
           cache: npm
@@ -150,7 +150,7 @@ jobs:
           ref: ${{ needs.release.outputs.tag }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: '22.22.1'
           cache: npm


### PR DESCRIPTION
Consolidates the 5 open Dependabot GitHub Actions bumps into a single PR:

- codecov/codecov-action 5 → 7 (supersedes #31)
- actions/dependency-review-action 4 → 5 (supersedes #30)
- actions/setup-node 5 → 7 (supersedes #29)
- actions/github-script 8 → 9 (supersedes #28)
- actions/labeler 6 → 7 (supersedes #27)